### PR TITLE
Block publish calls from outside the app engine cron

### DIFF
--- a/appengine/app.js
+++ b/appengine/app.js
@@ -13,6 +13,10 @@ const app = express();
 // For any request to /public/{some_topic}, push a simple
 // PubSub message to that topic.
 app.get('/publish/:topic', async (req, res) => {
+  if (!req.header('X-AppEngine-Cron')) {
+    return res.status(403).send('Unauthorized: only the app engine cron can call this')
+  }
+
   const topic = req.params['topic'];
 
   try {


### PR DESCRIPTION
Thought this project, even if very simple and mostly for demonstration purposes, could use a simple header check to make sure that none other than the app engine can call the publish route and deter the purpose of this app by triggering more jobs than expected.